### PR TITLE
move away from entity impl being genservers

### DIFF
--- a/lib/homex.ex
+++ b/lib/homex.ex
@@ -92,6 +92,8 @@ defmodule Homex do
 
   defdelegate connected?(), to: Homex.Manager
   defdelegate publish(topic, payload, opts), to: Homex.Manager
+  defdelegate entities(), to: Homex.Manager
+  defdelegate entity(name_or_module), to: Homex.Manager
   defdelegate add_entity(module), to: Homex.Manager
   defdelegate add_entities(modules), to: Homex.Manager
   defdelegate remove_entity(module), to: Homex.Manager

--- a/lib/homex/config.ex
+++ b/lib/homex/config.ex
@@ -49,7 +49,7 @@ defmodule Homex.Config do
                      doc:
                        "if changed in Homeassistant you also need to change it here to enable autodiscovery. The default works for a standard installation"
                    ],
-                   entities: [required: false, default: [], type: {:list, :atom}],
+                   entities: [required: false, default: [], type: {:list, :keyword_list}],
                    broker: [
                      required: false,
                      default: [],

--- a/lib/homex/entity.ex
+++ b/lib/homex/entity.ex
@@ -185,11 +185,8 @@ defmodule Homex.Entity do
   end
 
   @impl GenServer
-  def handle_cast({:push_value, key, value}, entity) do
-    {:noreply, entity |> put_change(key, value) |> execute_change()}
-  end
-
-  # Fallback, passes the casted msg along to the implementation for handling
+  # Fallback, passes the casted msg along to the implementation for handling and
+  # calling execute_change after.
   def handle_cast(msg, %{impl: impl} = entity) do
     entity = impl.handle_cast(msg, entity) |> execute_change()
     {:noreply, entity}

--- a/lib/homex/entity.ex
+++ b/lib/homex/entity.ex
@@ -44,7 +44,7 @@ defmodule Homex.Entity do
           handlers: map(),
           changes: map(),
           private: map(),
-          impl: Module.t() | nil
+          impl: Module.t()
         }
 
   defstruct values: %{}, changes: %{}, handlers: %{}, keys: MapSet.new(), private: %{}, impl: nil
@@ -158,7 +158,7 @@ defmodule Homex.Entity do
 
   @impl GenServer
   def init(opts) do
-    entity = new(impl: Keyword.get(opts, :impl))
+    entity = new(impl: Keyword.fetch!(opts, :impl))
 
     case entity.impl.update_interval() do
       :never -> :ok

--- a/lib/homex/entity/device_trigger.ex
+++ b/lib/homex/entity/device_trigger.ex
@@ -71,8 +71,6 @@ defmodule Homex.Entity.DeviceTrigger do
       @device_type opts[:type]
       @subtype opts[:subtype]
 
-      def trigger, do: GenServer.cast(__MODULE__, {:push_value, :trigger, @payload})
-
       @impl Homex.Entity
       def name, do: @name
 

--- a/lib/homex/entity/device_trigger.ex
+++ b/lib/homex/entity/device_trigger.ex
@@ -71,7 +71,7 @@ defmodule Homex.Entity.DeviceTrigger do
       @device_type opts[:type]
       @subtype opts[:subtype]
 
-      def trigger, do: GenServer.cast(__MODULE__, :trigger)
+      def trigger, do: GenServer.cast(__MODULE__, {:push_value, :trigger, @payload})
 
       @impl Homex.Entity
       def name, do: @name
@@ -109,12 +109,6 @@ defmodule Homex.Entity.DeviceTrigger do
 
       @impl Homex.Entity
       def handle_init(entity), do: super(entity)
-
-      @impl GenServer
-      def handle_cast(:trigger, entity) do
-        entity |> Entity.put_change(:trigger, @payload) |> Entity.execute_change()
-        {:noreply, entity}
-      end
 
       defoverridable handle_init: 1
     end

--- a/lib/homex/entity/sensor.ex
+++ b/lib/homex/entity/sensor.ex
@@ -101,6 +101,8 @@ defmodule Homex.Entity.Sensor do
       @state_class opts[:state_class]
       @retain opts[:retain]
 
+      def send_value(val), do: GenServer.cast(__MODULE__, {:push_value, :state, val})
+
       @impl Homex.Entity
       def name, do: @name
 

--- a/lib/homex/entity/sensor.ex
+++ b/lib/homex/entity/sensor.ex
@@ -101,8 +101,6 @@ defmodule Homex.Entity.Sensor do
       @state_class opts[:state_class]
       @retain opts[:retain]
 
-      def send_value(val), do: GenServer.cast(__MODULE__, {:push_value, :state, val})
-
       @impl Homex.Entity
       def name, do: @name
 


### PR DESCRIPTION
- now all started entities as Home.Entity with a %Entity{impl: module_name} of the implementation


re #33 