### PR TITLE
Use `@payload_press` module attribute instead of undefined `@action`

### DIFF
--- a/lib/homex/entity/button.ex
+++ b/lib/homex/entity/button.ex
@@ -98,7 +98,7 @@ defmodule Homex.Entity.Button do
         entity
       end
 
-      def handle_message({@command_topic, @action}, entity) do
+      def handle_message({@command_topic, @payload_press}, entity) do
         entity |> handle_press()
       end
 


### PR DESCRIPTION
Thanks for creating this project! I started replacing my custom MQTT integrations with Homex.

I noticed that Button matched on `@action` but that wasn't defined anywhere.
Looks like one of the force pushes in #27 renamed `action` to `payload_press` but one case was forgotten.