### PR TITLE
Fix/registry start order

### DIFF
--- a/lib/homex.ex
+++ b/lib/homex.ex
@@ -12,8 +12,12 @@ defmodule Homex do
 
     children = [
       {DynamicSupervisor, name: Homex.EntitySupervisor, strategy: :one_for_one},
-      {Homex.Manager, config},
+      # Registry must start before the Manager: on MQTT connect the Manager
+      # runs Registry.select(Homex.SubscriptionRegistry, ...) from its
+      # :subscribe_to_topics continuation. With a fast (LAN) broker that ran
+      # before the registry existed, crashing the tree with "unknown registry".
       {Registry, name: Homex.SubscriptionRegistry, keys: :duplicate, listeners: [Homex.Manager]},
+      {Homex.Manager, config},
       {Task, fn -> Homex.add_entities(config.entities) end}
     ]
 

--- a/lib/homex.ex
+++ b/lib/homex.ex
@@ -12,7 +12,7 @@ defmodule Homex do
 
     children = [
       {DynamicSupervisor, name: Homex.EntitySupervisor, strategy: :one_for_one},
-      # Registry must start before the Manager to avoid a race
+      # Registry must start before the Manager
       {Registry, name: Homex.SubscriptionRegistry, keys: :duplicate, listeners: [Homex.Manager]},
       {Homex.Manager, config},
       {Task, fn -> Homex.add_entities(config.entities) end}

--- a/lib/homex.ex
+++ b/lib/homex.ex
@@ -12,10 +12,7 @@ defmodule Homex do
 
     children = [
       {DynamicSupervisor, name: Homex.EntitySupervisor, strategy: :one_for_one},
-      # Registry must start before the Manager: on MQTT connect the Manager
-      # runs Registry.select(Homex.SubscriptionRegistry, ...) from its
-      # :subscribe_to_topics continuation. With a fast (LAN) broker that ran
-      # before the registry existed, crashing the tree with "unknown registry".
+      # Registry must start before the Manager to avoid a race
       {Registry, name: Homex.SubscriptionRegistry, keys: :duplicate, listeners: [Homex.Manager]},
       {Homex.Manager, config},
       {Task, fn -> Homex.add_entities(config.entities) end}


### PR DESCRIPTION
Start SubscriptionRegistry before Manager
On MQTT connect the Manager runs Registry.select(Homex.SubscriptionRegistry,
...) from its :connect -> :subscribe_to_topics continuation. Under
rest_for_one the Manager was started before the registry, so with a fast
(LAN) broker the select could run before the registry existed, crashing with
ArgumentError 'unknown registry' and taking down the supervision tree.

Start the registry ahead of the Manager. Its :listeners process (the Manager)
is only needed when entities register, which happens later via add_entities.