### PR TITLE
fix: some mqtt platforms needs full entity state on publish

### DIFF
--- a/lib/homex/adapter.ex
+++ b/lib/homex/adapter.ex
@@ -22,12 +22,19 @@ defmodule Homex.Adapter do
   @callback child_spec({name(), opts :: keyword(), ctx :: map()}) :: Supervisor.child_spec()
 
   @doc """
-  Delivers the committed state diff of an entity.
+  Delivers a committed change of an entity.
 
-  Called after every entity change commit with the entity's descriptor and a
-  map of the fields that actually changed.
+  Called after every entity change commit with the entity's descriptor, the values
+  of all fields after the commit and the fields that actually changed. A transport
+  that reports a full snapshot per message builds it from `values`; a transport
+  with one topic per field uses `changes` to publish only what changed.
   """
-  @callback publish_state(name(), descriptor :: Homex.Descriptor.t(), changes :: map()) :: :ok
+  @callback publish_state(
+              name(),
+              descriptor :: Homex.Descriptor.t(),
+              values :: map(),
+              changes :: map()
+            ) :: :ok
 
   @doc """
   Signals that entities were added or removed, so the adapter can update

--- a/lib/homex/adapter/mqtt.ex
+++ b/lib/homex/adapter/mqtt.ex
@@ -38,8 +38,8 @@ defmodule Homex.Adapter.MQTT do
   end
 
   @impl Homex.Adapter
-  def publish_state(instance, %Homex.Descriptor{} = descriptor, changes) do
-    GenServer.cast(instance, {:publish_state, descriptor, changes})
+  def publish_state(instance, %Homex.Descriptor{} = descriptor, values, changes) do
+    GenServer.cast(instance, {:publish_state, descriptor, values, changes})
   end
 
   @impl Homex.Adapter
@@ -265,14 +265,14 @@ defmodule Homex.Adapter.MQTT do
 
   @impl GenServer
   def handle_cast(
-        {:publish_state, %Homex.Descriptor{} = descriptor, changes},
+        {:publish_state, %Homex.Descriptor{} = descriptor, values, changes},
         %__MODULE__{node_id: node_id, emqtt_pid: emqtt_pid, connected: true} = state
       )
       when not is_nil(emqtt_pid) do
     if resolved = resolve(node_id, descriptor) do
       opts = [retain: descriptor.transport[:mqtt][:retain]]
 
-      for {topic, payload} <- resolved.mod.publish(descriptor, resolved.topics, changes) do
+      for {topic, payload} <- resolved.mod.publish(descriptor, resolved.topics, values, changes) do
         with :ok <- :emqtt.publish(emqtt_pid, topic, payload, opts) do
           Logger.debug("published #{inspect(payload)} to #{inspect(topic)}")
         end

--- a/lib/homex/adapter/mqtt/button.ex
+++ b/lib/homex/adapter/mqtt/button.ex
@@ -27,6 +27,8 @@ defmodule Homex.Adapter.MQTT.Button do
   def normalize(_payload), do: nil
 
   @impl Homex.Adapter.MQTT.Platform
-  def publish(_desc, topics, %{attrs: attrs}), do: [{topics.attributes, Homex.encode!(attrs)}]
-  def publish(_desc, _topics, _changes), do: []
+  def publish(_desc, topics, _values, %{attrs: attrs}),
+    do: [{topics.attributes, Homex.encode!(attrs)}]
+
+  def publish(_desc, _topics, _values, _changes), do: []
 end

--- a/lib/homex/adapter/mqtt/camera.ex
+++ b/lib/homex/adapter/mqtt/camera.ex
@@ -25,7 +25,7 @@ defmodule Homex.Adapter.MQTT.Camera do
   def normalize(_payload), do: nil
 
   @impl Homex.Adapter.MQTT.Platform
-  def publish(_desc, topics, changes) do
+  def publish(_desc, topics, _values, changes) do
     Enum.flat_map(changes, fn
       {:image, image} -> [{topics.image, image}]
       {:attrs, attrs} -> [{topics.attributes, Homex.encode!(attrs)}]

--- a/lib/homex/adapter/mqtt/device_trigger.ex
+++ b/lib/homex/adapter/mqtt/device_trigger.ex
@@ -25,6 +25,8 @@ defmodule Homex.Adapter.MQTT.DeviceTrigger do
   def normalize(_payload), do: nil
 
   @impl Homex.Adapter.MQTT.Platform
-  def publish(desc, topics, %{trigger: true}), do: [{topics.action, desc.options[:payload]}]
-  def publish(_desc, _topics, _changes), do: []
+  def publish(desc, topics, _values, %{trigger: true}),
+    do: [{topics.action, desc.options[:payload]}]
+
+  def publish(_desc, _topics, _values, _changes), do: []
 end

--- a/lib/homex/adapter/mqtt/light.ex
+++ b/lib/homex/adapter/mqtt/light.ex
@@ -35,13 +35,19 @@ defmodule Homex.Adapter.MQTT.Light do
   def normalize(_payload), do: nil
 
   @impl Homex.Adapter.MQTT.Platform
-  def publish(_desc, topics, changes) do
-    payload =
-      %{}
-      |> maybe_put("state", changes[:state], &wire_state/1)
-      |> maybe_put("brightness", changes[:brightness], &wire_brightness/1)
+  # ha reads a json light message as a full snapshot, so the state goes into every
+  # message, also when only the brightness changed
+  def publish(_desc, topics, values, _changes) do
+    case wire_state(values[:state]) do
+      nil ->
+        []
 
-    if payload == %{}, do: [], else: [{topics.state, Homex.encode!(payload)}]
+      state ->
+        payload =
+          maybe_put(%{"state" => state}, "brightness", values[:brightness], &wire_brightness/1)
+
+        [{topics.state, Homex.encode!(payload)}]
+    end
   end
 
   defp color_modes(modes), do: if(:brightness in modes, do: ["brightness"], else: ["onoff"])
@@ -72,6 +78,7 @@ defmodule Homex.Adapter.MQTT.Light do
 
   defp wire_state(true), do: "ON"
   defp wire_state(false), do: "OFF"
+  defp wire_state(_), do: nil
 
   defp wire_brightness(value), do: round(value / 100 * 255)
 end

--- a/lib/homex/adapter/mqtt/platform.ex
+++ b/lib/homex/adapter/mqtt/platform.ex
@@ -11,6 +11,6 @@ defmodule Homex.Adapter.MQTT.Platform do
   @callback component(Homex.Descriptor.t(), topics()) :: map()
   @callback subscriptions(Homex.Descriptor.t(), topics()) :: [String.t()]
   @callback normalize(payload :: term()) :: map() | nil
-  @callback publish(Homex.Descriptor.t(), topics(), changes :: map()) ::
+  @callback publish(Homex.Descriptor.t(), topics(), values :: map(), changes :: map()) ::
               [{topic :: String.t(), payload :: iodata()}]
 end

--- a/lib/homex/adapter/mqtt/sensor.ex
+++ b/lib/homex/adapter/mqtt/sensor.ex
@@ -24,6 +24,8 @@ defmodule Homex.Adapter.MQTT.Sensor do
   def normalize(_payload), do: nil
 
   @impl Homex.Adapter.MQTT.Platform
-  def publish(_desc, topics, %{state: value}), do: [{topics.state, Homex.encode!(value)}]
-  def publish(_desc, _topics, _changes), do: []
+  def publish(_desc, topics, %{state: value}, _changes),
+    do: [{topics.state, Homex.encode!(value)}]
+
+  def publish(_desc, _topics, _values, _changes), do: []
 end

--- a/lib/homex/adapter/mqtt/switch.ex
+++ b/lib/homex/adapter/mqtt/switch.ex
@@ -29,7 +29,7 @@ defmodule Homex.Adapter.MQTT.Switch do
   def normalize(_payload), do: nil
 
   @impl Homex.Adapter.MQTT.Platform
-  def publish(_desc, topics, %{state: true}), do: [{topics.state, @on_payload}]
-  def publish(_desc, topics, %{state: false}), do: [{topics.state, @off_payload}]
-  def publish(_desc, _topics, _changes), do: []
+  def publish(_desc, topics, %{state: true}, _changes), do: [{topics.state, @on_payload}]
+  def publish(_desc, topics, %{state: false}, _changes), do: [{topics.state, @off_payload}]
+  def publish(_desc, _topics, _values, _changes), do: []
 end

--- a/lib/homex/entity.ex
+++ b/lib/homex/entity.ex
@@ -233,13 +233,15 @@ defmodule Homex.Entity do
         {key, value}
       end
 
+    values = Map.merge(values, diff)
+
     if map_size(diff) != 0 do
       for {module, instance} <- Homex.adapters() do
-        module.publish_state(instance, entity.descriptor, diff)
+        module.publish_state(instance, entity.descriptor, values, diff)
       end
     end
 
-    %{entity | changes: %{}, values: Map.merge(values, diff)}
+    %{entity | changes: %{}, values: values}
   end
 
   ## Process lifecycle

--- a/test/homex/entity/light_test.exs
+++ b/test/homex/entity/light_test.exs
@@ -110,6 +110,33 @@ defmodule Homex.Entity.LightTest do
     end
   end
 
+  describe "MQTT publish" do
+    alias Homex.Adapter.MQTT
+
+    @desc %Descriptor{kind: :light, name: "test-light", fields: %{state: :state}}
+    @topics %{state: "homex/light/id", command: "homex/light/id/set"}
+
+    test "the state is in every message, also when only the brightness changed" do
+      values = %{state: true, brightness: 78}
+
+      assert [{"homex/light/id", payload}] =
+               MQTT.Light.publish(@desc, @topics, values, %{brightness: 78})
+
+      assert Homex.decode!(payload) == %{"state" => "ON", "brightness" => 199}
+    end
+
+    test "an off light reports its brightness too" do
+      assert [{_topic, payload}] =
+               MQTT.Light.publish(@desc, @topics, %{state: false, brightness: 0}, %{state: false})
+
+      assert Homex.decode!(payload) == %{"state" => "OFF", "brightness" => 0}
+    end
+
+    test "no message while the state is unknown" do
+      assert [] == MQTT.Light.publish(@desc, @topics, %{brightness: 78}, %{brightness: 78})
+    end
+  end
+
   describe "MQTT normalize" do
     alias Homex.Adapter.MQTT
 

--- a/test/support/test_adapter.ex
+++ b/test/support/test_adapter.ex
@@ -2,7 +2,7 @@ defmodule Homex.Adapter.Test do
   @moduledoc """
   A `Homex.Adapter` for tests.
 
-  Forwards every `publish_state/3` as `{:publish_state, descriptor, changes}`
+  Forwards every `publish_state/4` as `{:publish_state, descriptor, changes}`
   and every `entities_changed/1` as `:entities_changed` to the attached process:
 
       Homex.Adapter.Test.attach()
@@ -29,7 +29,7 @@ defmodule Homex.Adapter.Test do
   end
 
   @impl Homex.Adapter
-  def publish_state(_instance, descriptor, changes) do
+  def publish_state(_instance, descriptor, _values, changes) do
     notify_attached({:publish_state, descriptor, changes})
   end
 


### PR DESCRIPTION
The unique id is needed for MQTT but not for ESPHome.
So it get's removed from core and moves into the
MQTT layer